### PR TITLE
feat: add somali xlsum dataset downloader

### DIFF
--- a/crates/corpus-tools/Cargo.toml
+++ b/crates/corpus-tools/Cargo.toml
@@ -46,6 +46,10 @@ path = "src/bin/merge_corpora.rs"
 name = "download_wikipedia_so"
 path = "src/bin/download_wikipedia_so.rs"
 
+[[bin]]
+name = "download_xlsum_so"
+path = "src/bin/download_xlsum_so.rs"
+
 [dependencies]
 common = { path = "../common" }
 anyhow = { workspace = true }

--- a/crates/corpus-tools/src/bin/download_xlsum_so.rs
+++ b/crates/corpus-tools/src/bin/download_xlsum_so.rs
@@ -1,0 +1,94 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::{Parser, ValueEnum};
+use corpus_tools::cli::{LimitArgs, StreamArgs};
+use corpus_tools::xlsum::{self, download_xlsum};
+
+const DEFAULT_OUTPUT: &str = "data/raw/xlsum/xlsum_so.jsonl";
+
+/// Which XL-Sum column to export as the record text.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Field {
+    /// Full article body (default; the monolingual corpus signal).
+    Text,
+    /// Human-written abstractive summary.
+    Summary,
+    /// Article headline.
+    Title,
+}
+
+impl Field {
+    fn column(self) -> &'static str {
+        match self {
+            Field::Text => "text",
+            Field::Summary => "summary",
+            Field::Title => "title",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Split {
+    Train,
+    Validation,
+    Test,
+}
+
+impl Split {
+    fn name(self) -> &'static str {
+        match self {
+            Split::Train => "train",
+            Split::Validation => "validation",
+            Split::Test => "test",
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+#[command(about = "Download the Somali XL-Sum subset and export JSONL")]
+struct Args {
+    #[arg(long, default_value = DEFAULT_OUTPUT)]
+    output: PathBuf,
+
+    /// Column exported as the record text.
+    #[arg(long, value_enum, default_value = "text")]
+    field: Field,
+
+    /// Splits to export, in the given order.
+    #[arg(long, value_enum, num_args = 1.., default_values = ["train", "validation", "test"])]
+    splits: Vec<Split>,
+
+    #[command(flatten)]
+    limit: LimitArgs,
+
+    #[command(flatten)]
+    stream: StreamArgs,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let splits: Vec<String> = args
+        .splits
+        .iter()
+        .map(|split| split.name().to_string())
+        .collect();
+
+    println!(
+        "Downloading {} (config: {}) — splits: {}, field: {}",
+        xlsum::DATASET_NAME,
+        xlsum::DATASET_CONFIG,
+        splits.join(", "),
+        args.field.column()
+    );
+
+    download_xlsum(
+        &args.output,
+        args.field.column(),
+        &splits,
+        args.limit.limit,
+        args.stream.streaming(),
+    )?;
+
+    Ok(())
+}

--- a/crates/corpus-tools/src/hf.rs
+++ b/crates/corpus-tools/src/hf.rs
@@ -7,6 +7,19 @@ use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::blocking::Client;
 use serde::Deserialize;
 
+/// Default branch: every dataset that ships its files on `main`.
+pub const MAIN_REVISION: &str = "main";
+
+/// Auto-converted parquet branch the Hub publishes for script-based datasets
+/// (those the modern `datasets` library can no longer load by config name).
+pub const PARQUET_REVISION: &str = "refs/convert/parquet";
+
+/// Percent-encode a git revision so refs like `refs/convert/parquet` survive as
+/// a single URL path segment — the Hub returns 404 for unencoded slashes.
+fn encode_revision(revision: &str) -> String {
+    revision.replace('/', "%2F")
+}
+
 #[derive(Debug, Deserialize)]
 struct TreeEntry {
     #[serde(rename = "type")]
@@ -35,7 +48,26 @@ impl HfClient {
     }
 
     pub fn list_files(&self, repo: &str, prefix: &str) -> Result<Vec<String>> {
-        let url = format!("https://huggingface.co/api/datasets/{repo}/tree/main/{prefix}");
+        self.list_files_at(repo, MAIN_REVISION, prefix, false)
+    }
+
+    pub fn list_files_recursive(&self, repo: &str, prefix: &str) -> Result<Vec<String>> {
+        self.list_files_at(repo, MAIN_REVISION, prefix, true)
+    }
+
+    /// List files under `prefix` at an arbitrary revision (branch, tag, or ref
+    /// such as [`PARQUET_REVISION`]).
+    pub fn list_files_at(
+        &self,
+        repo: &str,
+        revision: &str,
+        prefix: &str,
+        recursive: bool,
+    ) -> Result<Vec<String>> {
+        let revision = encode_revision(revision);
+        let query = if recursive { "?recursive=true" } else { "" };
+        let url =
+            format!("https://huggingface.co/api/datasets/{repo}/tree/{revision}/{prefix}{query}");
         let mut request = self.client.get(&url);
         if let Some(token) = &self.token {
             request = request.bearer_auth(token);
@@ -43,7 +75,7 @@ impl HfClient {
 
         let response = request.send().context("listing Hugging Face dataset files")?;
         if response.status() == reqwest::StatusCode::NOT_FOUND {
-            bail!("dataset path not found: {repo}/{prefix}");
+            bail!("dataset path not found: {repo}@{revision}/{prefix}");
         }
         if response.status() == reqwest::StatusCode::UNAUTHORIZED
             || response.status() == reqwest::StatusCode::FORBIDDEN
@@ -52,32 +84,7 @@ impl HfClient {
         }
         if !response.status().is_success() {
             bail!(
-                "failed to list files for {repo}/{prefix}: {}",
-                response.status()
-            );
-        }
-
-        let entries: Vec<TreeEntry> = response.json().context("parsing HF tree response")?;
-        Ok(entries
-            .into_iter()
-            .filter(|entry| entry.entry_type == "file")
-            .map(|entry| entry.path)
-            .collect())
-    }
-
-    pub fn list_files_recursive(&self, repo: &str, prefix: &str) -> Result<Vec<String>> {
-        let url = format!(
-            "https://huggingface.co/api/datasets/{repo}/tree/main/{prefix}?recursive=true"
-        );
-        let mut request = self.client.get(&url);
-        if let Some(token) = &self.token {
-            request = request.bearer_auth(token);
-        }
-
-        let response = request.send().context("listing Hugging Face dataset files")?;
-        if !response.status().is_success() {
-            bail!(
-                "failed to list files for {repo}/{prefix}: {}",
+                "failed to list files for {repo}@{revision}/{prefix}: {}",
                 response.status()
             );
         }
@@ -91,7 +98,19 @@ impl HfClient {
     }
 
     pub fn download_to_path(&self, repo: &str, remote_path: &str, destination: &Path) -> Result<()> {
-        let url = format!("https://huggingface.co/datasets/{repo}/resolve/main/{remote_path}");
+        self.download_to_path_at(repo, MAIN_REVISION, remote_path, destination)
+    }
+
+    /// Download a single file from an arbitrary revision.
+    pub fn download_to_path_at(
+        &self,
+        repo: &str,
+        revision: &str,
+        remote_path: &str,
+        destination: &Path,
+    ) -> Result<()> {
+        let revision = encode_revision(revision);
+        let url = format!("https://huggingface.co/datasets/{repo}/resolve/{revision}/{remote_path}");
         let mut request = self.client.get(&url);
         if let Some(token) = &self.token {
             request = request.bearer_auth(token);
@@ -143,6 +162,17 @@ impl HfClient {
         repo: &str,
         remote_path: &str,
     ) -> Result<(tempfile::NamedTempFile, PathBuf)> {
+        self.download_to_temp_at(repo, MAIN_REVISION, remote_path)
+    }
+
+    /// Download a single file from an arbitrary revision into a temp file whose
+    /// lifetime the caller owns.
+    pub fn download_to_temp_at(
+        &self,
+        repo: &str,
+        revision: &str,
+        remote_path: &str,
+    ) -> Result<(tempfile::NamedTempFile, PathBuf)> {
         let suffix = Path::new(remote_path)
             .extension()
             .and_then(|ext| ext.to_str())
@@ -150,8 +180,23 @@ impl HfClient {
             .unwrap_or_default();
         let temp = tempfile::Builder::new().suffix(&suffix).tempfile()?;
         let path = temp.path().to_path_buf();
-        self.download_to_path(repo, remote_path, &path)?;
+        self.download_to_path_at(repo, revision, remote_path, &path)?;
         Ok((temp, path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_slashes_in_refs() {
+        assert_eq!(encode_revision("refs/convert/parquet"), "refs%2Fconvert%2Fparquet");
+    }
+
+    #[test]
+    fn leaves_plain_branch_untouched() {
+        assert_eq!(encode_revision("main"), "main");
     }
 }
 

--- a/crates/corpus-tools/src/lib.rs
+++ b/crates/corpus-tools/src/lib.rs
@@ -11,5 +11,6 @@ pub mod parquet_source;
 pub mod quran;
 pub mod stats;
 pub mod wikipedia;
+pub mod xlsum;
 
 pub use stats::Stats;

--- a/crates/corpus-tools/src/xlsum.rs
+++ b/crates/corpus-tools/src/xlsum.rs
@@ -1,0 +1,203 @@
+//! XL-Sum Somali (`csebuetnlp/xlsum`) downloader.
+//!
+//! The repo still ships a (now unsupported) dataset *script*, so the config is
+//! not loadable by name. The Hub auto-converts such datasets to parquet on
+//! [`PARQUET_REVISION`], which we read instead — one `0000.parquet` shard per
+//! split, holding `id` / `url` / `title` / `summary` / `text`.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Result};
+use tempfile::NamedTempFile;
+
+use crate::hf::{HfClient, PARQUET_REVISION};
+use crate::jsonl::{is_non_empty, JsonlWriter};
+use crate::parquet_source::iter_text_column;
+
+pub const SOURCE_TAG: &str = "xlsum";
+pub const DATASET_NAME: &str = "csebuetnlp/xlsum";
+pub const DATASET_CONFIG: &str = "somali";
+
+/// Splits published for the Somali configuration.
+pub const SPLITS: [&str; 3] = ["train", "validation", "test"];
+
+/// Parquet columns that hold text worth exporting.
+pub const FIELDS: [&str; 3] = ["text", "summary", "title"];
+
+/// Human-readable provenance line for the export summary.
+pub fn source_url() -> String {
+    format!(
+        "https://huggingface.co/datasets/{DATASET_NAME} (config: {DATASET_CONFIG}, \
+         revision: {PARQUET_REVISION})"
+    )
+}
+
+/// Download the requested Somali XL-Sum splits and export one JSONL record per
+/// article, carrying the chosen `field` as `text`.
+///
+/// No cleaning happens here: like every other downloader in this crate, the
+/// output is raw source text and normalization is the corpus-pipeline's job.
+pub fn download_xlsum(
+    output: &Path,
+    field: &str,
+    splits: &[String],
+    limit: Option<u64>,
+    streaming: bool,
+) -> Result<crate::Stats> {
+    if !FIELDS.contains(&field) {
+        bail!("unknown field '{field}'; expected one of {}", FIELDS.join(", "));
+    }
+
+    let hf = HfClient::new();
+    let listed = hf.list_files_at(DATASET_NAME, PARQUET_REVISION, DATASET_CONFIG, true)?;
+    let shards = select_shards(&listed, splits)?;
+
+    let mut writer = JsonlWriter::create(output, "Writing")?;
+    let mut written = 0u64;
+    let mut temps: Vec<NamedTempFile> = Vec::new();
+
+    for remote_path in &shards {
+        if limit.is_some_and(|limit| written >= limit) {
+            break;
+        }
+
+        let local_path = resolve_shard(&hf, remote_path, output, streaming, &mut temps)?;
+
+        for text in iter_text_column(&local_path, field)? {
+            if limit.is_some_and(|limit| written >= limit) {
+                break;
+            }
+            let text = text?;
+            if !is_non_empty(&text) {
+                continue;
+            }
+            writer.write_text(&text)?;
+            written += 1;
+        }
+    }
+
+    let stats = writer.stats.clone();
+    writer.finish();
+
+    if stats.total_docs == 0 {
+        bail!("no documents exported from {DATASET_NAME}");
+    }
+
+    crate::cli::print_export_summary(
+        "XL-Sum Somali export complete",
+        &stats,
+        output,
+        &source_url(),
+    );
+    Ok(stats)
+}
+
+/// Pick the parquet shards belonging to `splits`, in the order requested.
+///
+/// Errors when a requested split has no shards, so a renamed split upstream
+/// fails loudly instead of silently exporting a short corpus.
+fn select_shards(listed: &[String], splits: &[String]) -> Result<Vec<String>> {
+    if splits.is_empty() {
+        bail!("no splits requested; expected one or more of {}", SPLITS.join(", "));
+    }
+
+    let mut shards = Vec::new();
+    for split in splits {
+        let prefix = format!("{DATASET_CONFIG}/{split}/");
+        let mut matched: Vec<String> = listed
+            .iter()
+            .filter(|path| path.starts_with(&prefix) && path.ends_with(".parquet"))
+            .cloned()
+            .collect();
+        if matched.is_empty() {
+            bail!("no parquet shards found for split '{split}' under {DATASET_CONFIG}/");
+        }
+        matched.sort();
+        shards.append(&mut matched);
+    }
+    Ok(shards)
+}
+
+fn resolve_shard(
+    hf: &HfClient,
+    remote_path: &str,
+    output: &Path,
+    streaming: bool,
+    temps: &mut Vec<NamedTempFile>,
+) -> Result<PathBuf> {
+    if streaming {
+        let (temp, path) = hf.download_to_temp_at(DATASET_NAME, PARQUET_REVISION, remote_path)?;
+        temps.push(temp);
+        return Ok(path);
+    }
+
+    let path = output
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(local_shard_name(remote_path));
+    hf.download_to_path_at(DATASET_NAME, PARQUET_REVISION, remote_path, &path)?;
+    Ok(path)
+}
+
+/// Flatten a remote shard path into a unique local filename.
+///
+/// Every split names its shard `0000.parquet`, so keeping only the file name
+/// would make the three splits overwrite each other on disk.
+fn local_shard_name(remote_path: &str) -> String {
+    let flattened = remote_path.trim_start_matches('/').replace('/', "_");
+    format!("{SOURCE_TAG}_{flattened}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn listing() -> Vec<String> {
+        vec![
+            "somali/test/0000.parquet".to_string(),
+            "somali/train/0000.parquet".to_string(),
+            "somali/validation/0000.parquet".to_string(),
+        ]
+    }
+
+    fn splits(names: &[&str]) -> Vec<String> {
+        names.iter().map(|name| name.to_string()).collect()
+    }
+
+    #[test]
+    fn selects_shards_in_requested_order() {
+        let shards = select_shards(&listing(), &splits(&["train", "test"])).unwrap();
+        assert_eq!(
+            shards,
+            vec!["somali/train/0000.parquet", "somali/test/0000.parquet"]
+        );
+    }
+
+    #[test]
+    fn split_prefix_does_not_match_by_substring() {
+        // "valid" must not pick up the "validation" shard.
+        assert!(select_shards(&listing(), &splits(&["valid"])).is_err());
+    }
+
+    #[test]
+    fn missing_split_is_an_error() {
+        assert!(select_shards(&listing(), &splits(&["dev"])).is_err());
+    }
+
+    #[test]
+    fn empty_split_list_is_an_error() {
+        assert!(select_shards(&listing(), &[]).is_err());
+    }
+
+    #[test]
+    fn local_shard_names_stay_unique_per_split() {
+        assert_eq!(
+            local_shard_name("somali/train/0000.parquet"),
+            "xlsum_somali_train_0000.parquet"
+        );
+        assert_ne!(
+            local_shard_name("somali/train/0000.parquet"),
+            local_shard_name("somali/test/0000.parquet")
+        );
+    }
+}


### PR DESCRIPTION
Adds `download_xlsum_so`, exporting the Somali config of csebuetnlp/xlsum (train/validation/test) to JSONL.

The repo ships a legacy dataset script, so the config is not loadable by name; the shards are read from the Hub auto-converted parquet branch instead. That required revision support in HfClient: `list_files_at` / `download_to_path_at` / `download_to_temp_at`, with the ref percent-encoded (the Hub 404s on unencoded slashes). Existing callers delegate through the new methods on `main`, unchanged.

`--field` selects text (default), summary, or title; `--splits` selects and orders the splits. Local shard names are prefixed per split so the three `0000.parquet` files cannot overwrite each other in non-streaming mode.