### PR TITLE
feat(xlsum): modularize XL-Sum downloader and add staged parquet toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,25 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **XL-Sum Somali staged toolkit** (`crates/corpus-tools/src/xlsum/`, binary `xlsum_so`) —
+  download → inspect → extract → clean → export → stats, ported from the Python
+  `xlsum_somali` package; writes `extracted.jsonl`, `corpus.{jsonl,csv,txt}` and
+  `reports/{schema,metadata_report}.json` under one root
+- Somali-safe cleaner (NFC, control/zero-width/bidi stripping, whitespace collapse,
+  mojibake and length gates) preserving letters, glottal stops and diacritics
+- `parquet_source::iter_string_rows` / `row_count` / `column_types` for multi-column
+  and footer-only parquet reads
 - **Somali BPE tokenizer pipeline** (`tokenizer/`) — prepare, train, and benchmark scripts
   using Hugging Face `tokenizers` on the final release corpus
 - Trained **32k vocabulary** model: `tokenizer/somali-bpe-tokenizer.json`
 - Full-corpus benchmark: mean **1.53** tokens/word (native) vs **2.69** (BERT-base) vs
   **1.94** (XLM-RoBERTa) on 1,668,080 documents
 - Technical note: [tokenizer/PAPER.md](tokenizer/PAPER.md)
+
+### Fixed
+
+- `download_wikipedia` took `Option<usize>` while its binary passed `Option<u64>`,
+  which failed to compile the whole crate
 
 ### Planned
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "unicode-normalization",
  "xz2",
 ]
 

--- a/README.md
+++ b/README.md
@@ -164,9 +164,30 @@ cargo build --release
 ./target/release/download_madlad_so
 ./target/release/download_mt560_so
 ./target/release/download_quran_so
+./target/release/download_wikipedia_so
+./target/release/download_xlsum_so
 
 ./target/release/run_pipeline --config configs/pipeline.toml
 ```
+
+### XL-Sum staged toolkit
+
+`download_xlsum_so` writes raw single-field JSONL like every other downloader.
+`xlsum_so` runs the source's own six-stage toolkit instead — download → inspect →
+extract → clean → export → stats — producing a cleaned corpus in JSONL/CSV/plain
+text plus schema and metadata reports under one root:
+
+```bash
+./target/release/xlsum_so all                       # every stage
+./target/release/xlsum_so all --splits train --limit 100
+./target/release/xlsum_so extract --splits train validation
+./target/release/xlsum_so clean --min-text-chars 40
+./target/release/xlsum_so export --formats jsonl txt
+./target/release/xlsum_so stats --tokens-per-word 1.53
+```
+
+Artifacts land under `--root` (default `data/raw/xlsum/`): `raw/` shards,
+`extracted.jsonl`, `corpus.{jsonl,csv,txt}`, and `reports/`.
 
 Some Hugging Face datasets need authentication:
 
@@ -204,6 +225,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 | `download_madlad_so` | [MADLAD-400](https://huggingface.co/datasets/allenai/MADLAD-400) (`so`) | ODC-BY |
 | `download_mt560_so` | [MT560 en–so pairs](https://huggingface.co/datasets/michsethowusu/english-somali_sentence-pairs_mt560) | CC-BY-4.0 |
 | `download_quran_so` | [QuranEnc Somali (Yacob Yusuf)](https://quranenc.com/api/v1/translation/sura/somali_yacob/1) | see source |
+| `download_wikipedia_so` | [wikimedia/wikipedia](https://huggingface.co/datasets/wikimedia/wikipedia) (`20231101.so`) | CC-BY-SA-4.0 |
+| `download_xlsum_so` / `xlsum_so` | [csebuetnlp/xlsum](https://huggingface.co/datasets/csebuetnlp/xlsum) (`somali`) | CC-BY-NC-SA-4.0 |
 
 Scale estimates, overlap, and per-record licensing: [docs/SOURCES.md](docs/SOURCES.md).
 

--- a/crates/corpus-tools/Cargo.toml
+++ b/crates/corpus-tools/Cargo.toml
@@ -50,6 +50,10 @@ path = "src/bin/download_wikipedia_so.rs"
 name = "download_xlsum_so"
 path = "src/bin/download_xlsum_so.rs"
 
+[[bin]]
+name = "xlsum_so"
+path = "src/bin/xlsum_so.rs"
+
 [dependencies]
 common = { path = "../common" }
 anyhow = { workspace = true }
@@ -69,4 +73,5 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
+unicode-normalization = { workspace = true }
 xz2 = { workspace = true }

--- a/crates/corpus-tools/src/bin/xlsum_so.rs
+++ b/crates/corpus-tools/src/bin/xlsum_so.rs
@@ -1,0 +1,266 @@
+//! Staged XL-Sum Somali toolkit: run one stage at a time, or all six.
+//!
+//! For the plain single-field JSONL export used by the merge pipeline, see the
+//! `download_xlsum_so` binary instead.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use corpus_tools::xlsum::clean::{clean_records, CleanOptions};
+use corpus_tools::xlsum::config::{default_splits, Layout, DEFAULT_ROOT};
+use corpus_tools::xlsum::download::fetch_shards;
+use corpus_tools::xlsum::export::{export_formats, Format};
+use corpus_tools::xlsum::extract::{extract_records, load_records, save_records};
+use corpus_tools::xlsum::inspect::inspect_shards;
+use corpus_tools::xlsum::pipeline::{run_pipeline, PipelineOptions};
+use corpus_tools::xlsum::stats::{generate_report, TOKENS_PER_WORD};
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Split {
+    Train,
+    Validation,
+    Test,
+}
+
+impl Split {
+    fn name(self) -> &'static str {
+        match self {
+            Split::Train => "train",
+            Split::Validation => "validation",
+            Split::Test => "test",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum OutputFormat {
+    Jsonl,
+    Csv,
+    Txt,
+}
+
+impl OutputFormat {
+    fn format(self) -> Format {
+        match self {
+            OutputFormat::Jsonl => Format::Jsonl,
+            OutputFormat::Csv => Format::Csv,
+            OutputFormat::Txt => Format::Txt,
+        }
+    }
+}
+
+#[derive(Debug, Args)]
+struct SplitArgs {
+    /// Splits to process, in the given order.
+    #[arg(long, value_enum, num_args = 1.., default_values = ["train", "validation", "test"])]
+    splits: Vec<Split>,
+}
+
+impl SplitArgs {
+    fn names(&self) -> Vec<String> {
+        if self.splits.is_empty() {
+            return default_splits();
+        }
+        self.splits
+            .iter()
+            .map(|split| split.name().to_string())
+            .collect()
+    }
+}
+
+#[derive(Debug, Args)]
+struct CleanArgs {
+    /// Minimum cleaned text length (characters) to keep a record.
+    #[arg(long, default_value_t = 20)]
+    min_text_chars: usize,
+
+    /// Minimum cleaned title length (characters) to keep a record.
+    #[arg(long, default_value_t = 1)]
+    min_title_chars: usize,
+
+    /// Keep records whose summary is empty.
+    #[arg(long)]
+    allow_empty_summary: bool,
+}
+
+impl CleanArgs {
+    fn options(&self) -> CleanOptions {
+        CleanOptions {
+            min_text_chars: self.min_text_chars,
+            min_title_chars: self.min_title_chars,
+            require_summary: !self.allow_empty_summary,
+            ..CleanOptions::default()
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    about = "Download, clean and export the Somali XL-Sum corpus",
+    long_about = None
+)]
+struct Cli {
+    /// Root directory for every artefact (raw shards, corpus, reports).
+    #[arg(long, global = true, default_value = DEFAULT_ROOT)]
+    root: PathBuf,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// [1] Fetch the parquet shards into <root>/raw.
+    Download {
+        #[command(flatten)]
+        splits: SplitArgs,
+
+        /// Re-download shards that are already cached.
+        #[arg(long)]
+        force: bool,
+    },
+
+    /// [2] Report schema, row counts and sample records.
+    Inspect {
+        #[command(flatten)]
+        splits: SplitArgs,
+
+        /// Records to preview (0 disables previews).
+        #[arg(long, default_value_t = 3)]
+        samples: usize,
+
+        /// Split to preview from.
+        #[arg(long, value_enum, default_value = "train")]
+        preview_split: Split,
+    },
+
+    /// [3] Extract title/text/summary into <root>/extracted.jsonl.
+    Extract {
+        #[command(flatten)]
+        splits: SplitArgs,
+
+        /// Stop after N records.
+        #[arg(long)]
+        limit: Option<u64>,
+    },
+
+    /// [4] Clean and validate <root>/extracted.jsonl in place.
+    Clean {
+        #[command(flatten)]
+        clean: CleanArgs,
+    },
+
+    /// [5] Export the cleaned corpus to JSONL / CSV / plain text.
+    Export {
+        /// Formats to write.
+        #[arg(long, value_enum, num_args = 1.., default_values = ["jsonl", "csv", "txt"])]
+        formats: Vec<OutputFormat>,
+
+        #[command(flatten)]
+        clean: CleanArgs,
+    },
+
+    /// [6] Write the corpus metadata report.
+    Stats {
+        /// Tokens-per-word multiplier for the token estimate.
+        #[arg(long, default_value_t = TOKENS_PER_WORD)]
+        tokens_per_word: f64,
+    },
+
+    /// Run every stage end to end.
+    All {
+        #[command(flatten)]
+        splits: SplitArgs,
+
+        /// Re-download shards that are already cached.
+        #[arg(long)]
+        force: bool,
+
+        /// Records to preview during the inspect stage.
+        #[arg(long, default_value_t = 3)]
+        samples: usize,
+
+        /// Stop after N records.
+        #[arg(long)]
+        limit: Option<u64>,
+
+        #[command(flatten)]
+        clean: CleanArgs,
+
+        /// Tokens-per-word multiplier for the token estimate.
+        #[arg(long, default_value_t = TOKENS_PER_WORD)]
+        tokens_per_word: f64,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let layout = Layout::new(cli.root.clone());
+
+    match cli.command {
+        Command::Download { splits, force } => {
+            fetch_shards(&layout, &splits.names(), force)?;
+        }
+
+        Command::Inspect {
+            splits,
+            samples,
+            preview_split,
+        } => {
+            let shards = fetch_shards(&layout, &splits.names(), false)?;
+            inspect_shards(
+                &layout.schema_report(),
+                &shards,
+                samples,
+                preview_split.name(),
+            )?;
+        }
+
+        Command::Extract { splits, limit } => {
+            let shards = fetch_shards(&layout, &splits.names(), false)?;
+            let records = extract_records(&shards, limit)?;
+            save_records(&layout.extracted(), &records)?;
+        }
+
+        Command::Clean { clean } => {
+            let records = load_records(&layout.extracted())?;
+            let (cleaned, _drops) = clean_records(&records, &clean.options());
+            save_records(&layout.extracted(), &cleaned)?;
+        }
+
+        Command::Export { formats, clean } => {
+            let records = load_records(&layout.extracted())?;
+            let (cleaned, _drops) = clean_records(&records, &clean.options());
+            let formats: Vec<Format> = formats.iter().map(|format| format.format()).collect();
+            export_formats(&layout, &cleaned, &formats)?;
+        }
+
+        Command::Stats { tokens_per_word } => {
+            let records = load_records(&layout.extracted())?;
+            generate_report(&layout.stats_report(), &records, tokens_per_word)?;
+        }
+
+        Command::All {
+            splits,
+            force,
+            samples,
+            limit,
+            clean,
+            tokens_per_word,
+        } => {
+            let options = PipelineOptions {
+                splits: splits.names(),
+                force,
+                samples,
+                limit,
+                clean: clean.options(),
+                tokens_per_word,
+                ..PipelineOptions::default()
+            };
+            run_pipeline(&layout, &options)?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/corpus-tools/src/parquet_source.rs
+++ b/crates/corpus-tools/src/parquet_source.rs
@@ -24,6 +24,52 @@ pub fn iter_text_column(path: &Path, column: &str) -> Result<impl Iterator<Item 
     }))
 }
 
+/// Read several string columns at once, yielding one `Vec<String>` per row in
+/// the order `columns` was given.
+///
+/// Needed when a record keeps provenance alongside its text (XL-Sum carries
+/// `id` / `url` next to `title` / `text` / `summary`); [`iter_text_column`]
+/// would require one pass per column and could not zip the passes back into
+/// rows safely.
+pub fn iter_string_rows(
+    path: &Path,
+    columns: &[String],
+) -> Result<impl Iterator<Item = Result<Vec<String>>>> {
+    let columns: Vec<String> = columns.to_vec();
+    let file = File::open(path).with_context(|| format!("opening parquet file {}", path.display()))?;
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)?
+        .build()
+        .context("building parquet reader")?;
+
+    Ok(reader.flat_map(move |batch| {
+        let batch = match batch {
+            Ok(batch) => batch,
+            Err(error) => return vec![Err(error.into())],
+        };
+        extract_string_rows(&batch, &columns)
+    }))
+}
+
+/// Row count recorded in a parquet file's footer (no row scan required).
+pub fn row_count(path: &Path) -> Result<u64> {
+    let file = File::open(path).with_context(|| format!("opening parquet file {}", path.display()))?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    let rows = builder.metadata().file_metadata().num_rows();
+    Ok(rows.max(0) as u64)
+}
+
+/// Column names paired with their arrow data type, read from the footer.
+pub fn column_types(path: &Path) -> Result<Vec<(String, String)>> {
+    let file = File::open(path).with_context(|| format!("opening parquet file {}", path.display()))?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    Ok(builder
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| (field.name().clone(), format!("{:?}", field.data_type())))
+        .collect())
+}
+
 pub fn iter_struct_field(
     path: &Path,
     column: &str,
@@ -54,6 +100,29 @@ fn extract_string_column(batch: &RecordBatch, column: &str) -> Vec<Result<String
 
     let array = batch.column(index);
     string_values(array, column)
+}
+
+fn extract_string_rows(batch: &RecordBatch, columns: &[String]) -> Vec<Result<Vec<String>>> {
+    let mut per_column = Vec::with_capacity(columns.len());
+    for column in columns {
+        let mut values = Vec::with_capacity(batch.num_rows());
+        for value in extract_string_column(batch, column) {
+            match value {
+                Ok(value) => values.push(value),
+                Err(error) => return vec![Err(error)],
+            }
+        }
+        per_column.push(values);
+    }
+
+    (0..batch.num_rows())
+        .map(|row| {
+            Ok(per_column
+                .iter()
+                .map(|values| values[row].clone())
+                .collect::<Vec<String>>())
+        })
+        .collect()
 }
 
 fn extract_struct_string_field(batch: &RecordBatch, column: &str, field: &str) -> Vec<Result<String>> {

--- a/crates/corpus-tools/src/wikipedia.rs
+++ b/crates/corpus-tools/src/wikipedia.rs
@@ -10,7 +10,7 @@ pub const DATASET_NAME: &str = "wikimedia/wikipedia";
 pub const DATASET_CONFIG: &str = "20231101.so";
 
 /// Downloads the Somali Wikipedia subset from Hugging Face and exports it as JSONL.
-pub fn download_wikipedia(output: &Path, limit: Option<usize>, stream: bool) -> Result<()> {
+pub fn download_wikipedia(output: &Path, limit: Option<u64>, stream: bool) -> Result<()> {
     let hf = HfClient::new();
     let shards = filter_paths(hf.list_files(DATASET_NAME, DATASET_CONFIG)?, ".parquet");
 

--- a/crates/corpus-tools/src/xlsum/clean.rs
+++ b/crates/corpus-tools/src/xlsum/clean.rs
@@ -1,0 +1,279 @@
+//! Stage 4 — normalize and validate extracted records.
+//!
+//! Cleaning steps
+//! * Unicode normalization (NFC) so composed/decomposed forms compare equal.
+//! * Removal of control / zero-width / bidi-format characters that break
+//!   downstream tooling.
+//! * Whitespace collapse (every run of whitespace becomes one space) and trim,
+//!   which also guarantees one document per line in the plain-text export.
+//! * Rejection of empty, too-short, or mojibake-corrupted records.
+//!
+//! Somali is written in the Latin script, so normalization deliberately keeps
+//! every letter, apostrophe (glottal stop) and diacritic intact — only
+//! genuinely non-textual code points are removed.
+
+use unicode_normalization::UnicodeNormalization;
+
+use crate::xlsum::record::XlsumRecord;
+
+/// U+FFFD; a high proportion of these signals a decoding failure upstream.
+const REPLACEMENT_CHAR: char = '\u{FFFD}';
+
+/// Share of U+FFFD above which a value is treated as corrupted.
+pub const MAX_REPLACEMENT_RATIO: f64 = 0.02;
+
+/// Gates a cleaned record must clear to be kept.
+#[derive(Debug, Clone, Copy)]
+pub struct CleanOptions {
+    pub min_text_chars: usize,
+    pub min_title_chars: usize,
+    pub require_summary: bool,
+    pub max_replacement_ratio: f64,
+}
+
+impl Default for CleanOptions {
+    fn default() -> Self {
+        Self {
+            min_text_chars: 20,
+            min_title_chars: 1,
+            require_summary: true,
+            max_replacement_ratio: MAX_REPLACEMENT_RATIO,
+        }
+    }
+}
+
+/// Why a record was dropped, for the stage summary.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DropCounts {
+    pub too_short: u64,
+    pub missing_title: u64,
+    pub missing_summary: u64,
+    pub corrupted: u64,
+}
+
+impl DropCounts {
+    pub fn total(&self) -> u64 {
+        self.too_short + self.missing_title + self.missing_summary + self.corrupted
+    }
+}
+
+/// NFC-normalize, strip non-textual code points, collapse whitespace, trim.
+pub fn clean_text(text: &str) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+
+    let normalized: String = text.nfc().filter(|ch| !is_stripped(*ch)).collect();
+
+    let mut out = String::with_capacity(normalized.len());
+    let mut last_was_space = false;
+    for ch in normalized.trim().chars() {
+        if ch.is_whitespace() {
+            if !last_was_space {
+                out.push(' ');
+                last_was_space = true;
+            }
+        } else {
+            out.push(ch);
+            last_was_space = false;
+        }
+    }
+    out
+}
+
+/// Control, zero-width, BOM and bidi-format code points.
+///
+/// Real newlines and tabs survive this pass and are collapsed to spaces by the
+/// whitespace pass, matching the reference Python cleaner.
+fn is_stripped(ch: char) -> bool {
+    if ch == '\n' || ch == '\t' {
+        return false;
+    }
+    if ch.is_control() {
+        return true;
+    }
+    matches!(
+        ch,
+        '\u{00AD}'                 // soft hyphen
+            | '\u{200B}'..='\u{200F}'  // zero-width space/joiners, LRM/RLM
+            | '\u{202A}'..='\u{202E}'  // bidi embedding/override
+            | '\u{2060}'..='\u{2064}'  // word joiner, invisible operators
+            | '\u{FEFF}'               // BOM / zero-width no-break space
+            | '\u{FFF9}'..='\u{FFFB}' // interlinear annotation
+    )
+}
+
+/// Whether `text` looks mojibake-corrupted.
+pub fn is_corrupted(text: &str, max_replacement_ratio: f64) -> bool {
+    if text.is_empty() {
+        return false;
+    }
+    let total = text.chars().count() as f64;
+    let replacements = text.chars().filter(|ch| *ch == REPLACEMENT_CHAR).count() as f64;
+    replacements / total > max_replacement_ratio
+}
+
+/// Clean one record, returning `None` when it fails a gate.
+pub fn clean_record(
+    record: &XlsumRecord,
+    options: &CleanOptions,
+    drops: &mut DropCounts,
+) -> Option<XlsumRecord> {
+    let title = clean_text(&record.title);
+    let text = clean_text(&record.text);
+    let summary = clean_text(&record.summary);
+
+    if text.chars().count() < options.min_text_chars {
+        drops.too_short += 1;
+        return None;
+    }
+    if title.chars().count() < options.min_title_chars {
+        drops.missing_title += 1;
+        return None;
+    }
+    if options.require_summary && summary.is_empty() {
+        drops.missing_summary += 1;
+        return None;
+    }
+    let ratio = options.max_replacement_ratio;
+    if is_corrupted(&text, ratio) || is_corrupted(&title, ratio) || is_corrupted(&summary, ratio) {
+        drops.corrupted += 1;
+        return None;
+    }
+
+    Some(XlsumRecord {
+        id: record.id.clone(),
+        url: record.url.clone(),
+        split: record.split.clone(),
+        title,
+        text,
+        summary,
+    })
+}
+
+/// Clean a batch of records, dropping the invalid ones.
+pub fn clean_records(
+    records: &[XlsumRecord],
+    options: &CleanOptions,
+) -> (Vec<XlsumRecord>, DropCounts) {
+    let mut cleaned = Vec::with_capacity(records.len());
+    let mut drops = DropCounts::default();
+
+    for record in records {
+        if let Some(record) = clean_record(record, options, &mut drops) {
+            cleaned.push(record);
+        }
+    }
+
+    println!(
+        "Cleaned {} record(s); dropped {} (short: {}, no title: {}, no summary: {}, corrupted: {}).",
+        cleaned.len(),
+        drops.total(),
+        drops.too_short,
+        drops.missing_title,
+        drops.missing_summary,
+        drops.corrupted
+    );
+    (cleaned, drops)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(text: &str) -> XlsumRecord {
+        XlsumRecord {
+            id: "1".into(),
+            url: "https://example.test/1".into(),
+            split: "train".into(),
+            title: "Cinwaan".into(),
+            text: text.into(),
+            summary: "Kooban".into(),
+        }
+    }
+
+    #[test]
+    fn collapses_whitespace_and_trims() {
+        assert_eq!(
+            clean_text("  Suudaan   oo\nbaadigoobaysa  "),
+            "Suudaan oo baadigoobaysa"
+        );
+    }
+
+    #[test]
+    fn strips_zero_width_and_bom() {
+        assert_eq!(clean_text("Soo\u{200B}maali\u{FEFF}ya"), "Soomaaliya");
+    }
+
+    #[test]
+    fn preserves_somali_letters_and_glottal_stop() {
+        let text = "Ma'aan arag shaqaale'da Soomaaliyeed — 'daawo'";
+        assert_eq!(clean_text(text), text);
+    }
+
+    #[test]
+    fn nfc_composes_decomposed_forms() {
+        // "é" written as e + combining acute must equal the composed form.
+        assert_eq!(clean_text("cafe\u{0301}"), clean_text("caf\u{00E9}"));
+    }
+
+    #[test]
+    fn empty_input_stays_empty() {
+        assert_eq!(clean_text("   \n\t "), "");
+    }
+
+    #[test]
+    fn corruption_needs_more_than_the_ratio() {
+        let mostly_fine = format!("{}\u{FFFD}", "a".repeat(200));
+        assert!(!is_corrupted(&mostly_fine, MAX_REPLACEMENT_RATIO));
+        assert!(is_corrupted("\u{FFFD}\u{FFFD}ab", MAX_REPLACEMENT_RATIO));
+        assert!(!is_corrupted("", MAX_REPLACEMENT_RATIO));
+    }
+
+    #[test]
+    fn short_text_is_dropped() {
+        let mut drops = DropCounts::default();
+        assert!(clean_record(&record("gaaban"), &CleanOptions::default(), &mut drops).is_none());
+        assert_eq!(drops.too_short, 1);
+    }
+
+    #[test]
+    fn missing_summary_is_dropped_unless_optional() {
+        let mut source = record("Qoraal dheer oo ku filan gudbinta xadka.");
+        source.summary = String::new();
+
+        let mut drops = DropCounts::default();
+        assert!(clean_record(&source, &CleanOptions::default(), &mut drops).is_none());
+        assert_eq!(drops.missing_summary, 1);
+
+        let options = CleanOptions {
+            require_summary: false,
+            ..CleanOptions::default()
+        };
+        let mut drops = DropCounts::default();
+        assert!(clean_record(&source, &options, &mut drops).is_some());
+    }
+
+    #[test]
+    fn valid_record_keeps_its_provenance() {
+        let mut drops = DropCounts::default();
+        let cleaned = clean_record(
+            &record("  Qoraal   dheer oo ku filan gudbinta xadka.  "),
+            &CleanOptions::default(),
+            &mut drops,
+        )
+        .unwrap();
+        assert_eq!(cleaned.text, "Qoraal dheer oo ku filan gudbinta xadka.");
+        assert_eq!(cleaned.url, "https://example.test/1");
+        assert_eq!(cleaned.split, "train");
+        assert_eq!(drops.total(), 0);
+    }
+
+    #[test]
+    fn min_text_chars_counts_characters_not_bytes() {
+        // 21 two-byte characters: over the 20-char gate, under it if counted wrong.
+        let mut drops = DropCounts::default();
+        let text = "é".repeat(21);
+        assert!(clean_record(&record(&text), &CleanOptions::default(), &mut drops).is_some());
+    }
+}

--- a/crates/corpus-tools/src/xlsum/config.rs
+++ b/crates/corpus-tools/src/xlsum/config.rs
@@ -1,0 +1,132 @@
+//! Source configuration and the on-disk layout every XL-Sum stage writes to.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::hf::PARQUET_REVISION;
+
+pub const SOURCE_TAG: &str = "xlsum";
+pub const DATASET_NAME: &str = "csebuetnlp/xlsum";
+pub const DATASET_CONFIG: &str = "somali";
+
+/// Splits published for the Somali configuration.
+pub const SPLITS: [&str; 3] = ["train", "validation", "test"];
+
+/// Parquet columns that hold text worth exporting as a record's `text`.
+pub const FIELDS: [&str; 3] = ["text", "summary", "title"];
+
+/// Every column the pipeline reads: the three text fields plus provenance.
+pub const COLUMNS: [&str; 5] = ["id", "url", "title", "text", "summary"];
+
+/// Default root for the staged pipeline artefacts.
+pub const DEFAULT_ROOT: &str = "data/raw/xlsum";
+
+/// Human-readable provenance line for the export summary.
+pub fn source_url() -> String {
+    format!(
+        "https://huggingface.co/datasets/{DATASET_NAME} (config: {DATASET_CONFIG}, \
+         revision: {PARQUET_REVISION})"
+    )
+}
+
+/// All splits, as owned strings — the default for every stage.
+pub fn default_splits() -> Vec<String> {
+    SPLITS.iter().map(|split| split.to_string()).collect()
+}
+
+/// The artefact tree the staged pipeline produces under a single root.
+///
+/// Mirrors the layout of the reference Python toolkit so both produce
+/// interchangeable outputs:
+///
+/// ```text
+/// <root>/
+/// ├── raw/                          downloaded parquet shards
+/// ├── extracted.jsonl               extracted (then cleaned) records
+/// ├── corpus.jsonl / .csv / .txt    exported corpus
+/// └── reports/schema.json, metadata_report.json
+/// ```
+#[derive(Debug, Clone)]
+pub struct Layout {
+    root: PathBuf,
+}
+
+impl Layout {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn raw_dir(&self) -> PathBuf {
+        self.root.join("raw")
+    }
+
+    pub fn reports_dir(&self) -> PathBuf {
+        self.root.join("reports")
+    }
+
+    pub fn extracted(&self) -> PathBuf {
+        self.root.join("extracted.jsonl")
+    }
+
+    pub fn corpus_jsonl(&self) -> PathBuf {
+        self.root.join("corpus.jsonl")
+    }
+
+    pub fn corpus_csv(&self) -> PathBuf {
+        self.root.join("corpus.csv")
+    }
+
+    pub fn corpus_txt(&self) -> PathBuf {
+        self.root.join("corpus.txt")
+    }
+
+    pub fn schema_report(&self) -> PathBuf {
+        self.reports_dir().join("schema.json")
+    }
+
+    pub fn stats_report(&self) -> PathBuf {
+        self.reports_dir().join("metadata_report.json")
+    }
+
+    /// Create every directory the pipeline writes to.
+    pub fn ensure_dirs(&self) -> Result<()> {
+        for directory in [self.root.clone(), self.raw_dir(), self.reports_dir()] {
+            fs::create_dir_all(&directory)
+                .with_context(|| format!("creating directory {}", directory.display()))?;
+        }
+        Ok(())
+    }
+}
+
+impl Default for Layout {
+    fn default() -> Self {
+        Self::new(DEFAULT_ROOT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layout_paths_hang_off_the_root() {
+        let layout = Layout::new("out/xlsum");
+        assert_eq!(layout.raw_dir(), Path::new("out/xlsum/raw"));
+        assert_eq!(layout.extracted(), Path::new("out/xlsum/extracted.jsonl"));
+        assert_eq!(
+            layout.stats_report(),
+            Path::new("out/xlsum/reports/metadata_report.json")
+        );
+    }
+
+    #[test]
+    fn source_url_names_the_parquet_revision() {
+        assert!(source_url().contains(PARQUET_REVISION));
+    }
+}

--- a/crates/corpus-tools/src/xlsum/download.rs
+++ b/crates/corpus-tools/src/xlsum/download.rs
@@ -1,4 +1,4 @@
-//! XL-Sum Somali (`csebuetnlp/xlsum`) downloader.
+//! Stage 1 — fetch the Somali XL-Sum parquet shards from the Hub.
 //!
 //! The repo still ships a (now unsupported) dataset *script*, so the config is
 //! not loadable by name. The Hub auto-converts such datasets to parquet on
@@ -13,23 +13,16 @@ use tempfile::NamedTempFile;
 use crate::hf::{HfClient, PARQUET_REVISION};
 use crate::jsonl::{is_non_empty, JsonlWriter};
 use crate::parquet_source::iter_text_column;
+use crate::xlsum::config::{
+    source_url, Layout, DATASET_CONFIG, DATASET_NAME, FIELDS, SOURCE_TAG, SPLITS,
+};
 
-pub const SOURCE_TAG: &str = "xlsum";
-pub const DATASET_NAME: &str = "csebuetnlp/xlsum";
-pub const DATASET_CONFIG: &str = "somali";
-
-/// Splits published for the Somali configuration.
-pub const SPLITS: [&str; 3] = ["train", "validation", "test"];
-
-/// Parquet columns that hold text worth exporting.
-pub const FIELDS: [&str; 3] = ["text", "summary", "title"];
-
-/// Human-readable provenance line for the export summary.
-pub fn source_url() -> String {
-    format!(
-        "https://huggingface.co/datasets/{DATASET_NAME} (config: {DATASET_CONFIG}, \
-         revision: {PARQUET_REVISION})"
-    )
+/// A parquet shard on disk, tagged with the split it belongs to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Shard {
+    pub split: String,
+    pub remote_path: String,
+    pub local_path: PathBuf,
 }
 
 /// Download the requested Somali XL-Sum splits and export one JSONL record per
@@ -37,6 +30,7 @@ pub fn source_url() -> String {
 ///
 /// No cleaning happens here: like every other downloader in this crate, the
 /// output is raw source text and normalization is the corpus-pipeline's job.
+/// For the cleaned, multi-format corpus see [`crate::xlsum::pipeline`].
 pub fn download_xlsum(
     output: &Path,
     field: &str,
@@ -45,7 +39,10 @@ pub fn download_xlsum(
     streaming: bool,
 ) -> Result<crate::Stats> {
     if !FIELDS.contains(&field) {
-        bail!("unknown field '{field}'; expected one of {}", FIELDS.join(", "));
+        bail!(
+            "unknown field '{field}'; expected one of {}",
+            FIELDS.join(", ")
+        );
     }
 
     let hf = HfClient::new();
@@ -56,7 +53,7 @@ pub fn download_xlsum(
     let mut written = 0u64;
     let mut temps: Vec<NamedTempFile> = Vec::new();
 
-    for remote_path in &shards {
+    for (_, remote_path) in &shards {
         if limit.is_some_and(|limit| written >= limit) {
             break;
         }
@@ -92,13 +89,48 @@ pub fn download_xlsum(
     Ok(stats)
 }
 
+/// Materialize every requested split's shards under `layout.raw_dir()`.
+///
+/// Shards already on disk are reused unless `force` is set, so re-running the
+/// staged pipeline does not re-download the dataset.
+pub fn fetch_shards(layout: &Layout, splits: &[String], force: bool) -> Result<Vec<Shard>> {
+    layout.ensure_dirs()?;
+
+    let hf = HfClient::new();
+    let listed = hf.list_files_at(DATASET_NAME, PARQUET_REVISION, DATASET_CONFIG, true)?;
+    let selected = select_shards(&listed, splits)?;
+
+    let raw_dir = layout.raw_dir();
+    let mut shards = Vec::with_capacity(selected.len());
+
+    for (split, remote_path) in selected {
+        let local_path = raw_dir.join(local_shard_name(&remote_path));
+        if local_path.exists() && !force {
+            println!("  {split:<11} cached  {}", local_path.display());
+        } else {
+            println!("  {split:<11} -> {remote_path}");
+            hf.download_to_path_at(DATASET_NAME, PARQUET_REVISION, &remote_path, &local_path)?;
+        }
+        shards.push(Shard {
+            split,
+            remote_path,
+            local_path,
+        });
+    }
+
+    Ok(shards)
+}
+
 /// Pick the parquet shards belonging to `splits`, in the order requested.
 ///
 /// Errors when a requested split has no shards, so a renamed split upstream
 /// fails loudly instead of silently exporting a short corpus.
-fn select_shards(listed: &[String], splits: &[String]) -> Result<Vec<String>> {
+fn select_shards(listed: &[String], splits: &[String]) -> Result<Vec<(String, String)>> {
     if splits.is_empty() {
-        bail!("no splits requested; expected one or more of {}", SPLITS.join(", "));
+        bail!(
+            "no splits requested; expected one or more of {}",
+            SPLITS.join(", ")
+        );
     }
 
     let mut shards = Vec::new();
@@ -113,7 +145,7 @@ fn select_shards(listed: &[String], splits: &[String]) -> Result<Vec<String>> {
             bail!("no parquet shards found for split '{split}' under {DATASET_CONFIG}/");
         }
         matched.sort();
-        shards.append(&mut matched);
+        shards.extend(matched.into_iter().map(|path| (split.clone(), path)));
     }
     Ok(shards)
 }
@@ -164,13 +196,23 @@ mod tests {
         names.iter().map(|name| name.to_string()).collect()
     }
 
+    fn paths(shards: &[(String, String)]) -> Vec<&str> {
+        shards.iter().map(|(_, path)| path.as_str()).collect()
+    }
+
     #[test]
     fn selects_shards_in_requested_order() {
         let shards = select_shards(&listing(), &splits(&["train", "test"])).unwrap();
         assert_eq!(
-            shards,
+            paths(&shards),
             vec!["somali/train/0000.parquet", "somali/test/0000.parquet"]
         );
+    }
+
+    #[test]
+    fn tags_each_shard_with_its_split() {
+        let shards = select_shards(&listing(), &splits(&["validation"])).unwrap();
+        assert_eq!(shards[0].0, "validation");
     }
 
     #[test]

--- a/crates/corpus-tools/src/xlsum/export.rs
+++ b/crates/corpus-tools/src/xlsum/export.rs
@@ -1,0 +1,189 @@
+//! Stage 5 — write the cleaned corpus as JSONL, CSV and plain text.
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::xlsum::config::Layout;
+use crate::xlsum::record::XlsumRecord;
+
+/// Column order of the CSV export.
+pub const CSV_FIELDS: [&str; 6] = ["id", "url", "split", "title", "summary", "text"];
+
+/// UTF-8 byte order mark, written so Excel opens the CSV as UTF-8.
+const UTF8_BOM: &[u8] = &[0xEF, 0xBB, 0xBF];
+
+/// One of the three corpus formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    Jsonl,
+    Csv,
+    Txt,
+}
+
+impl Format {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Format::Jsonl => "jsonl",
+            Format::Csv => "csv",
+            Format::Txt => "txt",
+        }
+    }
+}
+
+/// Write one JSON object per line.
+pub fn export_jsonl(path: &Path, records: &[XlsumRecord]) -> Result<()> {
+    let mut writer = create(path)?;
+    for record in records {
+        writeln!(writer, "{}", serde_json::to_string(record)?)?;
+    }
+    finish(writer, path, records.len(), "JSONL")
+}
+
+/// Write the corpus as CSV (UTF-8 with BOM, RFC 4180 quoting).
+pub fn export_csv(path: &Path, records: &[XlsumRecord]) -> Result<()> {
+    let mut writer = create(path)?;
+    writer.write_all(UTF8_BOM)?;
+    writeln!(writer, "{}", CSV_FIELDS.join(","))?;
+
+    for record in records {
+        let row: Vec<String> = CSV_FIELDS
+            .iter()
+            .map(|field| csv_escape(csv_value(record, field)))
+            .collect();
+        writeln!(writer, "{}", row.join(","))?;
+    }
+    finish(writer, path, records.len(), "CSV")
+}
+
+/// Write one cleaned document (`text`) per line.
+///
+/// Cleaning already collapsed internal newlines, so every article occupies
+/// exactly one line.
+pub fn export_txt(path: &Path, records: &[XlsumRecord]) -> Result<()> {
+    let mut writer = create(path)?;
+    for record in records {
+        writeln!(writer, "{}", record.text)?;
+    }
+    finish(writer, path, records.len(), "plain-text")
+}
+
+/// Write the requested formats into the layout's corpus paths.
+pub fn export_formats(layout: &Layout, records: &[XlsumRecord], formats: &[Format]) -> Result<()> {
+    layout.ensure_dirs()?;
+    for format in formats {
+        match format {
+            Format::Jsonl => export_jsonl(&layout.corpus_jsonl(), records)?,
+            Format::Csv => export_csv(&layout.corpus_csv(), records)?,
+            Format::Txt => export_txt(&layout.corpus_txt(), records)?,
+        }
+    }
+    Ok(())
+}
+
+/// Write all three formats.
+pub fn export_all(layout: &Layout, records: &[XlsumRecord]) -> Result<()> {
+    export_formats(layout, records, &[Format::Jsonl, Format::Csv, Format::Txt])
+}
+
+fn csv_value<'a>(record: &'a XlsumRecord, field: &str) -> &'a str {
+    match field {
+        "id" => &record.id,
+        "url" => &record.url,
+        "split" => &record.split,
+        "title" => &record.title,
+        "summary" => &record.summary,
+        "text" => &record.text,
+        _ => "",
+    }
+}
+
+/// Quote a CSV field when it holds a comma, quote, or line break; doubling any
+/// embedded quotes.
+fn csv_escape(value: &str) -> String {
+    let needs_quotes = value.contains([',', '"', '\n', '\r']);
+    if !needs_quotes {
+        return value.to_string();
+    }
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+fn create(path: &Path) -> Result<BufWriter<File>> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating directory {}", parent.display()))?;
+    }
+    let file = File::create(path).with_context(|| format!("creating {}", path.display()))?;
+    Ok(BufWriter::new(file))
+}
+
+fn finish(mut writer: BufWriter<File>, path: &Path, count: usize, label: &str) -> Result<()> {
+    writer.flush()?;
+    println!("Wrote {count} {label} record(s) -> {}", path.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn records() -> Vec<XlsumRecord> {
+        vec![XlsumRecord {
+            id: "1".into(),
+            url: "https://example.test/1".into(),
+            split: "train".into(),
+            title: "Cinwaan, oo \"xigasho\" leh".into(),
+            text: "Qoraal dheer oo Soomaali ah.".into(),
+            summary: "Kooban".into(),
+        }]
+    }
+
+    #[test]
+    fn plain_values_are_not_quoted() {
+        assert_eq!(csv_escape("Soomaaliya"), "Soomaaliya");
+    }
+
+    #[test]
+    fn commas_and_quotes_are_escaped() {
+        assert_eq!(
+            csv_escape("Cinwaan, oo \"xigasho\" leh"),
+            "\"Cinwaan, oo \"\"xigasho\"\" leh\""
+        );
+    }
+
+    #[test]
+    fn csv_starts_with_a_bom_and_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corpus.csv");
+        export_csv(&path, &records()).unwrap();
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(bytes.starts_with(UTF8_BOM));
+        let body = String::from_utf8(bytes[3..].to_vec()).unwrap();
+        let mut lines = body.lines();
+        assert_eq!(lines.next().unwrap(), "id,url,split,title,summary,text");
+        assert!(lines.next().unwrap().contains("\"\"xigasho\"\""));
+    }
+
+    #[test]
+    fn txt_writes_one_document_per_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corpus.txt");
+        export_txt(&path, &records()).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(body.lines().count(), 1);
+        assert_eq!(body.trim_end(), "Qoraal dheer oo Soomaali ah.");
+    }
+
+    #[test]
+    fn jsonl_keeps_somali_characters_unescaped() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corpus.jsonl");
+        export_jsonl(&path, &records()).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(body.contains("Soomaali"));
+        assert_eq!(body.lines().count(), 1);
+    }
+}

--- a/crates/corpus-tools/src/xlsum/extract.rs
+++ b/crates/corpus-tools/src/xlsum/extract.rs
@@ -1,0 +1,142 @@
+//! Stage 3 — pull `title` / `text` / `summary` (plus provenance) out of the
+//! downloaded parquet shards.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::parquet_source::iter_string_rows;
+use crate::xlsum::config::{Layout, COLUMNS};
+use crate::xlsum::download::Shard;
+use crate::xlsum::record::XlsumRecord;
+
+/// Extract every record from `shards`, keeping the source `id` / `url` /
+/// `split` for traceability.
+///
+/// Values are returned exactly as stored upstream; [`crate::xlsum::clean`] is
+/// what normalizes them.
+pub fn extract_records(shards: &[Shard], limit: Option<u64>) -> Result<Vec<XlsumRecord>> {
+    let columns: Vec<String> = COLUMNS.iter().map(|name| name.to_string()).collect();
+    let mut records: Vec<XlsumRecord> = Vec::new();
+
+    for shard in shards {
+        if limit.is_some_and(|limit| records.len() as u64 >= limit) {
+            break;
+        }
+
+        let rows = iter_string_rows(&shard.local_path, &columns)
+            .with_context(|| format!("reading shard {}", shard.local_path.display()))?;
+
+        let before = records.len();
+        for row in rows {
+            if limit.is_some_and(|limit| records.len() as u64 >= limit) {
+                break;
+            }
+            let row = row?;
+            records.push(XlsumRecord {
+                id: row[0].clone(),
+                url: row[1].clone(),
+                split: shard.split.clone(),
+                title: row[2].clone(),
+                text: row[3].clone(),
+                summary: row[4].clone(),
+            });
+        }
+        println!("  {:<11} {} record(s)", shard.split, records.len() - before);
+    }
+
+    println!("Extracted {} record(s).", records.len());
+    Ok(records)
+}
+
+/// Persist records as JSON Lines, one object per line.
+pub fn save_records(path: &Path, records: &[XlsumRecord]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating directory {}", parent.display()))?;
+    }
+
+    let file = File::create(path).with_context(|| format!("creating {}", path.display()))?;
+    let mut writer = BufWriter::new(file);
+    for record in records {
+        writeln!(writer, "{}", serde_json::to_string(record)?)?;
+    }
+    writer.flush()?;
+
+    println!("Wrote {} record(s) -> {}", records.len(), path.display());
+    Ok(())
+}
+
+/// Read records previously written by [`save_records`].
+pub fn load_records(path: &Path) -> Result<Vec<XlsumRecord>> {
+    let file = File::open(path)
+        .with_context(|| format!("{} not found — run the extract stage first", path.display()))?;
+
+    let mut records = Vec::new();
+    for (index, line) in BufReader::new(file).lines().enumerate() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: XlsumRecord = serde_json::from_str(&line)
+            .with_context(|| format!("invalid JSON on line {} of {}", index + 1, path.display()))?;
+        records.push(record);
+    }
+    Ok(records)
+}
+
+/// Load extracted records for a later stage, extracting first if the JSONL is
+/// not on disk yet.
+pub fn load_or_extract(
+    layout: &Layout,
+    shards: &[Shard],
+    limit: Option<u64>,
+) -> Result<Vec<XlsumRecord>> {
+    let path = layout.extracted();
+    if path.exists() {
+        return load_records(&path);
+    }
+    println!("No {} — extracting from the raw shards.", path.display());
+    extract_records(shards, limit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Vec<XlsumRecord> {
+        vec![XlsumRecord {
+            id: "abc".into(),
+            url: "https://bbc.com/somali/1".into(),
+            split: "train".into(),
+            title: "Cinwaan".into(),
+            text: "Qoraal dheer oo Soomaali ah.".into(),
+            summary: "Kooban".into(),
+        }]
+    }
+
+    #[test]
+    fn jsonl_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("extracted.jsonl");
+        save_records(&path, &sample()).unwrap();
+        assert_eq!(load_records(&path).unwrap(), sample());
+    }
+
+    #[test]
+    fn blank_lines_are_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("extracted.jsonl");
+        std::fs::write(&path, "\n{\"text\":\"hal\"}\n\n").unwrap();
+        let records = load_records(&path).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].text, "hal");
+    }
+
+    #[test]
+    fn missing_file_is_an_error() {
+        assert!(load_records(Path::new("does/not/exist.jsonl")).is_err());
+    }
+}

--- a/crates/corpus-tools/src/xlsum/inspect.rs
+++ b/crates/corpus-tools/src/xlsum/inspect.rs
@@ -1,0 +1,141 @@
+//! Stage 2 — report the schema, per-split row counts, and a few samples.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::parquet_source::{column_types, iter_string_rows, row_count};
+use crate::xlsum::config::{COLUMNS, DATASET_CONFIG, DATASET_NAME};
+use crate::xlsum::download::Shard;
+
+/// Schema summary of the downloaded shards.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchemaReport {
+    pub repo: String,
+    pub config: String,
+    pub columns: Vec<String>,
+    pub features: BTreeMap<String, String>,
+    pub splits: BTreeMap<String, u64>,
+    pub total_rows: u64,
+}
+
+/// Build the schema report from the shards' parquet footers.
+pub fn build_schema_report(shards: &[Shard]) -> Result<SchemaReport> {
+    let first = shards
+        .first()
+        .context("no shards to inspect; run the download stage first")?;
+
+    let types = column_types(&first.local_path)?;
+    let columns: Vec<String> = types.iter().map(|(name, _)| name.clone()).collect();
+    let features: BTreeMap<String, String> = types.into_iter().collect();
+
+    let mut splits: BTreeMap<String, u64> = BTreeMap::new();
+    for shard in shards {
+        *splits.entry(shard.split.clone()).or_insert(0) += row_count(&shard.local_path)?;
+    }
+    let total_rows = splits.values().sum();
+
+    Ok(SchemaReport {
+        repo: DATASET_NAME.to_string(),
+        config: DATASET_CONFIG.to_string(),
+        columns,
+        features,
+        splits,
+        total_rows,
+    })
+}
+
+/// Print the schema plus `samples` preview records, and write the report.
+pub fn inspect_shards(
+    report_path: &Path,
+    shards: &[Shard],
+    samples: usize,
+    preview_split: &str,
+) -> Result<SchemaReport> {
+    let report = build_schema_report(shards)?;
+
+    println!("Repository : {} ({})", report.repo, report.config);
+    println!("Columns    : {}", report.columns.join(", "));
+    println!("Total rows : {}", report.total_rows);
+    for (split, rows) in &report.splits {
+        println!("  {split:<11} {rows} row(s)");
+    }
+    println!("Feature schema:");
+    for (name, feature) in &report.features {
+        println!("  - {name:<8} : {feature}");
+    }
+
+    if samples > 0 {
+        print_samples(shards, samples, preview_split)?;
+    }
+
+    if let Some(parent) = report_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating directory {}", parent.display()))?;
+    }
+    std::fs::write(report_path, serde_json::to_string_pretty(&report)? + "\n")
+        .with_context(|| format!("writing {}", report_path.display()))?;
+    println!("Schema report -> {}", report_path.display());
+
+    Ok(report)
+}
+
+fn print_samples(shards: &[Shard], samples: usize, preview_split: &str) -> Result<()> {
+    let shard = shards
+        .iter()
+        .find(|shard| shard.split == preview_split)
+        .or_else(|| shards.first())
+        .context("no shards available to preview")?;
+
+    println!("Previewing {samples} record(s) from '{}':", shard.split);
+    let columns: Vec<String> = COLUMNS.iter().map(|name| name.to_string()).collect();
+    for (index, row) in iter_string_rows(&shard.local_path, &columns)?
+        .take(samples)
+        .enumerate()
+    {
+        let row = row?;
+        println!("  [{index}] title  : {}", preview(&row[2]));
+        println!("      summary: {}", preview(&row[4]));
+        println!("      text   : {}", preview(&row[3]));
+    }
+    Ok(())
+}
+
+/// Single-line, truncated preview of a value.
+fn preview(value: &str) -> String {
+    const WIDTH: usize = 90;
+    let flattened: String = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if flattened.chars().count() <= WIDTH {
+        return flattened;
+    }
+    let head: String = flattened.chars().take(WIDTH).collect();
+    format!("{head}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preview_flattens_whitespace() {
+        assert_eq!(
+            preview("Suudaan   oo\nbaadigoobaysa"),
+            "Suudaan oo baadigoobaysa"
+        );
+    }
+
+    #[test]
+    fn preview_truncates_long_values_with_an_ellipsis() {
+        let long = "a".repeat(200);
+        let shortened = preview(&long);
+        assert_eq!(shortened.chars().count(), 91);
+        assert!(shortened.ends_with('…'));
+    }
+
+    #[test]
+    fn schema_report_needs_at_least_one_shard() {
+        assert!(build_schema_report(&[]).is_err());
+    }
+}

--- a/crates/corpus-tools/src/xlsum/mod.rs
+++ b/crates/corpus-tools/src/xlsum/mod.rs
@@ -1,0 +1,27 @@
+//! XL-Sum Somali (`csebuetnlp/xlsum`) toolkit.
+//!
+//! Two entry points share one source configuration:
+//!
+//! * [`download_xlsum`] — the raw single-field JSONL downloader every other
+//!   source in this crate also exposes (`download_xlsum_so` binary). Text is
+//!   left untouched; cleaning is the corpus-pipeline's job.
+//! * [`pipeline::run_pipeline`] — the staged toolkit (`xlsum_so` binary):
+//!   download → inspect → extract → clean → export → stats, producing a
+//!   cleaned corpus in JSONL / CSV / plain text plus schema and metadata
+//!   reports under one output root.
+
+pub mod clean;
+pub mod config;
+pub mod download;
+pub mod export;
+pub mod extract;
+pub mod inspect;
+pub mod pipeline;
+pub mod record;
+pub mod stats;
+
+pub use config::{
+    source_url, Layout, DATASET_CONFIG, DATASET_NAME, DEFAULT_ROOT, FIELDS, SOURCE_TAG, SPLITS,
+};
+pub use download::{download_xlsum, fetch_shards, Shard};
+pub use record::XlsumRecord;

--- a/crates/corpus-tools/src/xlsum/pipeline.rs
+++ b/crates/corpus-tools/src/xlsum/pipeline.rs
@@ -1,0 +1,82 @@
+//! Run every XL-Sum stage end to end: download → inspect → extract → clean →
+//! export → stats.
+
+use anyhow::Result;
+
+use crate::xlsum::clean::{clean_records, CleanOptions};
+use crate::xlsum::config::{default_splits, Layout};
+use crate::xlsum::download::fetch_shards;
+use crate::xlsum::export::{export_formats, Format};
+use crate::xlsum::extract::{extract_records, save_records};
+use crate::xlsum::inspect::inspect_shards;
+use crate::xlsum::stats::{generate_report, CorpusReport, TOKENS_PER_WORD};
+
+/// Knobs for a full pipeline run.
+#[derive(Debug, Clone)]
+pub struct PipelineOptions {
+    pub splits: Vec<String>,
+    /// Re-download shards that are already cached.
+    pub force: bool,
+    /// Preview records printed by the inspect stage (0 disables previews).
+    pub samples: usize,
+    pub limit: Option<u64>,
+    pub clean: CleanOptions,
+    pub formats: Vec<Format>,
+    pub tokens_per_word: f64,
+}
+
+impl Default for PipelineOptions {
+    fn default() -> Self {
+        Self {
+            splits: default_splits(),
+            force: false,
+            samples: 3,
+            limit: None,
+            clean: CleanOptions::default(),
+            formats: vec![Format::Jsonl, Format::Csv, Format::Txt],
+            tokens_per_word: TOKENS_PER_WORD,
+        }
+    }
+}
+
+/// Execute every stage and return the final metadata report.
+pub fn run_pipeline(layout: &Layout, options: &PipelineOptions) -> Result<CorpusReport> {
+    layout.ensure_dirs()?;
+
+    stage(1, "Download");
+    let shards = fetch_shards(layout, &options.splits, options.force)?;
+
+    stage(2, "Inspect");
+    inspect_shards(
+        &layout.schema_report(),
+        &shards,
+        options.samples,
+        options.splits.first().map_or("train", String::as_str),
+    )?;
+
+    stage(3, "Extract");
+    let records = extract_records(&shards, options.limit)?;
+    save_records(&layout.extracted(), &records)?;
+
+    stage(4, "Clean");
+    let (cleaned, _drops) = clean_records(&records, &options.clean);
+    save_records(&layout.extracted(), &cleaned)?;
+
+    stage(5, "Export");
+    export_formats(layout, &cleaned, &options.formats)?;
+
+    stage(6, "Stats");
+    let report = generate_report(&layout.stats_report(), &cleaned, options.tokens_per_word)?;
+
+    println!();
+    println!(
+        "Pipeline complete. Corpus available under {}",
+        layout.root().display()
+    );
+    Ok(report)
+}
+
+fn stage(number: u8, name: &str) {
+    println!();
+    println!("=== [{number}/6] {name} ===");
+}

--- a/crates/corpus-tools/src/xlsum/record.rs
+++ b/crates/corpus-tools/src/xlsum/record.rs
@@ -1,0 +1,54 @@
+//! The record shape carried between the extract, clean and export stages.
+
+use serde::{Deserialize, Serialize};
+
+/// One XL-Sum article.
+///
+/// `id` / `url` / `split` are kept purely for traceability; the corpus signal
+/// lives in `title` / `text` / `summary`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct XlsumRecord {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub url: String,
+    #[serde(default)]
+    pub split: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub text: String,
+    #[serde(default)]
+    pub summary: String,
+}
+
+impl XlsumRecord {
+    /// Read the field named by [`crate::xlsum::config::FIELDS`].
+    pub fn field(&self, field: &str) -> Option<&str> {
+        match field {
+            "text" => Some(&self.text),
+            "summary" => Some(&self.summary),
+            "title" => Some(&self.title),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_field_is_none() {
+        let record = XlsumRecord::default();
+        assert!(record.field("id").is_none());
+        assert!(record.field("text").is_some());
+    }
+
+    #[test]
+    fn missing_json_keys_default_to_empty() {
+        let record: XlsumRecord = serde_json::from_str(r#"{"text":"waa dal"}"#).unwrap();
+        assert_eq!(record.text, "waa dal");
+        assert!(record.url.is_empty());
+    }
+}

--- a/crates/corpus-tools/src/xlsum/stats.rs
+++ b/crates/corpus-tools/src/xlsum/stats.rs
@@ -1,0 +1,188 @@
+//! Stage 6 — corpus-level metadata report over the cleaned records.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::stats::{format_float, format_number};
+use crate::xlsum::config::{DATASET_CONFIG, DATASET_NAME};
+use crate::xlsum::record::XlsumRecord;
+
+/// Estimated subword tokens per whitespace-delimited word. ~1.53 is a
+/// reasonable estimate for Somali's Latin orthography under a modern
+/// multilingual subword tokenizer.
+pub const TOKENS_PER_WORD: f64 = 1.53;
+
+/// Statistics over the cleaned `text` field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CorpusReport {
+    pub repo: String,
+    pub config: String,
+    pub total_documents: u64,
+    pub total_characters: u64,
+    pub total_words: u64,
+    pub estimated_tokens: u64,
+    pub vocabulary_size: u64,
+    pub average_article_length_chars: f64,
+    pub average_article_length_words: f64,
+    pub tokens_per_word: f64,
+    pub tokens_estimation_basis: String,
+}
+
+/// Compute the report without writing it.
+pub fn compute_stats(records: &[XlsumRecord], tokens_per_word: f64) -> Result<CorpusReport> {
+    let word_re = Regex::new(r"\w+").context("compiling word regex")?;
+
+    let total_docs = records.len() as u64;
+    let mut total_chars = 0u64;
+    let mut total_words = 0u64;
+    let mut vocabulary: HashSet<String> = HashSet::new();
+
+    for record in records {
+        total_chars += record.text.chars().count() as u64;
+        for word in word_re.find_iter(&record.text.to_lowercase()) {
+            total_words += 1;
+            vocabulary.insert(word.as_str().to_string());
+        }
+    }
+
+    let (avg_chars, avg_words) = if total_docs == 0 {
+        (0.0, 0.0)
+    } else {
+        (
+            total_chars as f64 / total_docs as f64,
+            total_words as f64 / total_docs as f64,
+        )
+    };
+
+    Ok(CorpusReport {
+        repo: DATASET_NAME.to_string(),
+        config: DATASET_CONFIG.to_string(),
+        total_documents: total_docs,
+        total_characters: total_chars,
+        total_words,
+        estimated_tokens: (total_words as f64 * tokens_per_word).round() as u64,
+        vocabulary_size: vocabulary.len() as u64,
+        average_article_length_chars: round2(avg_chars),
+        average_article_length_words: round2(avg_words),
+        tokens_per_word,
+        tokens_estimation_basis: format!("total_words * {tokens_per_word}"),
+    })
+}
+
+/// Compute the report, print it, and write it as JSON.
+pub fn generate_report(
+    path: &Path,
+    records: &[XlsumRecord],
+    tokens_per_word: f64,
+) -> Result<CorpusReport> {
+    let report = compute_stats(records, tokens_per_word)?;
+    print_report(&report);
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating directory {}", parent.display()))?;
+    }
+    std::fs::write(path, serde_json::to_string_pretty(&report)? + "\n")
+        .with_context(|| format!("writing {}", path.display()))?;
+    println!("Metadata report -> {}", path.display());
+
+    Ok(report)
+}
+
+fn print_report(report: &CorpusReport) {
+    println!();
+    println!("{}", "=".repeat(48));
+    println!("XL-Sum Somali corpus metadata");
+    println!("{}", "=".repeat(48));
+    println!(
+        "Documents            : {}",
+        format_number(report.total_documents)
+    );
+    println!(
+        "Characters           : {}",
+        format_number(report.total_characters)
+    );
+    println!(
+        "Words                : {}",
+        format_number(report.total_words)
+    );
+    println!(
+        "Tokens (x{:.2})       : {}",
+        report.tokens_per_word,
+        format_number(report.estimated_tokens)
+    );
+    println!(
+        "Vocabulary size      : {}",
+        format_number(report.vocabulary_size)
+    );
+    println!(
+        "Avg doc length       : {} chars / {} words",
+        format_float(report.average_article_length_chars),
+        format_float(report.average_article_length_words)
+    );
+    println!("{}", "=".repeat(48));
+}
+
+fn round2(value: f64) -> f64 {
+    (value * 100.0).round() / 100.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(text: &str) -> XlsumRecord {
+        XlsumRecord {
+            text: text.into(),
+            ..XlsumRecord::default()
+        }
+    }
+
+    #[test]
+    fn counts_documents_chars_and_words() {
+        let records = vec![record("waa dal"), record("waa magaalo weyn")];
+        let report = compute_stats(&records, TOKENS_PER_WORD).unwrap();
+        assert_eq!(report.total_documents, 2);
+        assert_eq!(report.total_words, 5);
+        assert_eq!(report.total_characters, 23);
+    }
+
+    #[test]
+    fn vocabulary_is_case_folded_and_deduplicated() {
+        let records = vec![record("Dal dal DAL magaalo")];
+        let report = compute_stats(&records, TOKENS_PER_WORD).unwrap();
+        assert_eq!(report.total_words, 4);
+        assert_eq!(report.vocabulary_size, 2);
+    }
+
+    #[test]
+    fn tokens_scale_with_the_multiplier() {
+        let records = vec![record("waa dal wanaagsan oo weyn")];
+        let report = compute_stats(&records, 2.0).unwrap();
+        assert_eq!(report.estimated_tokens, 10);
+    }
+
+    #[test]
+    fn empty_corpus_reports_zero_averages() {
+        let report = compute_stats(&[], TOKENS_PER_WORD).unwrap();
+        assert_eq!(report.total_documents, 0);
+        assert_eq!(report.average_article_length_chars, 0.0);
+        assert_eq!(report.average_article_length_words, 0.0);
+    }
+
+    #[test]
+    fn report_is_written_as_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("reports/metadata_report.json");
+        generate_report(&path, &[record("waa dal")], TOKENS_PER_WORD).unwrap();
+
+        let written: CorpusReport =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(written.total_documents, 1);
+        assert_eq!(written.config, DATASET_CONFIG);
+    }
+}

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -20,6 +20,7 @@ See also: [METADATA_SCHEMA.md](METADATA_SCHEMA.md), [PLAN.md](../PLAN.md).
 | `opus` | OPUS ParaCrawl `en-so` | parallel text | A | parallel sentences | CC0-1.0 | `download_opus_so` | done | Somali column from `translation.so` |
 | `mt560` | MT560 en–so pairs | parallel / religious | A | ~161K pairs | CC-BY-4.0 | `download_mt560_so` | done | Writes `source: mt560` tag in raw JSONL |
 | `quran` | QuranEnc Somali (Yacob Yusuf) | religious | A | ~6.2K verses + footnotes | see source | `download_quran_so` | done | Two outputs: verse translations and footnote explanations |
+| `xlsum` | XL-Sum `somali` (BBC Somali) | news / summarization | A | ~7.5K articles, ~2.9M words | CC-BY-NC-SA-4.0 | `download_xlsum_so`, `xlsum_so` | done | Non-commercial license — keep separable from the redistributable corpus |
 
 ### Track A licensing note
 
@@ -105,6 +106,24 @@ from this registry (see [METADATA_SCHEMA.md](METADATA_SCHEMA.md)).
 - **Output:** `data/raw/quran/translation.json` (verse text) and `data/raw/quran/footnotes.json` (footnote explanations)
 - **Cleaning:** strips leading verse numbers and inline footnote markers from translations; strips leading `[n].` markers from footnotes; empty footnotes dropped
 - **License:** see upstream QuranEnc terms (verify before release)
+
+### `xlsum`
+
+- **Upstream:** [csebuetnlp/xlsum](https://huggingface.co/datasets/csebuetnlp/xlsum) config `somali` (BBC Somali articles)
+- **Access:** the repo still ships a dataset *script*, so the Hub's auto-converted
+  parquet branch `refs/convert/parquet` is read instead — one `0000.parquet` per
+  split, columns `id` / `url` / `title` / `summary` / `text`
+- **Splits:** `train` (5,962) · `validation` (745) · `test` (745)
+- **Output:** `data/raw/xlsum/xlsum_so.jsonl` (`download_xlsum_so`, raw single field)
+- **Staged toolkit:** `xlsum_so` writes `raw/` shards, `extracted.jsonl`,
+  `corpus.{jsonl,csv,txt}` and `reports/{schema,metadata_report}.json` under
+  `--root` (default `data/raw/xlsum/`)
+- **Cleaning (`xlsum_so` only):** NFC, control/zero-width/bidi removal, whitespace
+  collapse; drops records that are too short, untitled, summary-less, or
+  mojibake-corrupted (>2% U+FFFD). Somali letters, glottal-stop apostrophes and
+  diacritics are preserved
+- **License:** CC-BY-NC-SA-4.0 — **non-commercial**; verify before including in a
+  redistributed corpus build
 
 ---
 


### PR DESCRIPTION
## Summary

This PR splits the previous single-file `xlsum.rs` downloader into a proper module (`crates/corpus-tools/src/xlsum/`) and adds a new staged CLI toolkit for producing a cleaned, multi-format Somali XL-Sum corpus, alongside the existing raw JSONL downloader.

## What's changed

- Refactored `xlsum.rs` into `xlsum/{config, download, inspect, extract, clean, export, stats, pipeline, record}.rs`, separating dataset config, shard fetching, schema inspection, record extraction, text cleaning, multi-format export, and metadata reporting into distinct stages.
- Added a new binary, `xlsum_so`, exposing each stage as its own subcommand (`download`, `inspect`, `extract`, `clean`, `export`, `stats`) plus an `all` command that runs the full pipeline. The existing `download_xlsum_so` binary is preserved for the plain single-field JSONL output used by the merge pipeline.
- Added a Somali-aware text cleaner (NFC normalization, stripping of control/zero-width/bidi characters, whitespace collapsing, and mojibake/length gating) that preserves Somali letters, glottal stops, and diacritics.
- Extended `parquet_source` with `iter_string_rows`, `row_count`, and `column_types` to support multi-column and footer-only parquet reads (needed to keep provenance fields like `id`/`url` alongside `title`/`text`/`summary`).
- Fixed a type mismatch in `download_wikipedia` (`Option<usize>` vs. the binary's `Option<u64>`) that was breaking the crate build.
- Updated `CHANGELOG.md` and `README.md` with usage docs for the new `xlsum_so` toolkit and its output layout, and registered the new binary in `Cargo.toml` along with the `unicode-normalization` dependency.
- Added unit tests throughout the new modules (cleaning, CSV/JSONL/TXT export, extraction round-trips, schema inspection, shard selection).

## Output layout

The staged toolkit writes everything under one root (`data/raw/xlsum/` by default): raw parquet shards, `extracted.jsonl`, `corpus.{jsonl,csv,txt}`, and `reports/{schema,metadata_report}.json`.